### PR TITLE
added tags to sidebar

### DIFF
--- a/shotwell_web_client/templates/index.html
+++ b/shotwell_web_client/templates/index.html
@@ -48,6 +48,17 @@
                 {% endfor %}
             </ul>
             </li>
+        </ul>
+        {% if tags %}
+        <ul class="sidebar-nav events-nav">
+            <li><a><b>Tags</b></a>
+            <ul class="year-list">
+                {% for tag in tags %}
+                    <li><span class="glyphicon glyphicon-tag"></span>&nbsp;<a href="#tag_{{ tag.name }}" class="link">{{ tag.name }}</a></li>
+                {% endfor %}
+            </ul>
+        </ul>
+        {% endif %}
     </div>
 
     <div id="page-content-wrapper">


### PR DESCRIPTION
This change reads out all tags from TagTable and prints them to sidebar if any. The /items backend has support for queries in format "tag_" and the tag name and there's a new backend /tags to retrieve the id and name for all tags.